### PR TITLE
Add real-time scrolling oscilloscope/waveform viewer below spectrogram

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,16 @@
                 ></canvas>
             </div>
 
+            <!-- Oscilloscope Section -->
+            <div class="mb-6 bg-gray-800 rounded-lg p-4 shadow-lg">
+                <canvas 
+                    id="oscilloscope-canvas" 
+                    class="w-full bg-gray-950 rounded"
+                    width="800" 
+                    height="200"
+                ></canvas>
+            </div>
+
             <!-- Controls Section -->
             <div class="bg-gray-800 rounded-lg p-6 shadow-lg">
                 <div class="flex flex-col md:flex-row gap-6 items-center justify-center">
@@ -70,6 +80,21 @@
                             value="50" 
                             class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
                         />
+                    </div>
+
+                    <!-- View Length Dropdown -->
+                    <div class="flex flex-col gap-2 min-w-[150px]">
+                        <label for="view-length" class="text-sm font-medium text-gray-300">
+                            View Length
+                        </label>
+                        <select 
+                            id="view-length" 
+                            class="bg-gray-700 text-gray-100 border border-gray-600 rounded px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                            <option value="1">1 Bar</option>
+                            <option value="4" selected>4 Bars</option>
+                            <option value="8">8 Bars</option>
+                        </select>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Added oscilloscope canvas below spectrogram display
- Implemented real-time waveform scrolling (right to left)
- Added view length control (1 Bar, 4 Bars, 8 Bars) based on hardcoded 140 BPM
- Waveform features gradient coloring (blue->purple->red) similar to DJ software
- Zero-crossing centered waveform display
- Integrated with existing animation loop and audio processing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a scrolling oscilloscope beneath the spectrum with 1/4/8-bar view lengths (140 BPM), integrated into the render loop and responsive to resizing.
> 
> - **Visualization/UI**:
>   - Add `#oscilloscope-canvas` beneath `#rta-canvas` in `index.html`.
>   - New "View Length" dropdown (`#view-length`) with 1/4/8 bars.
> - **Oscilloscope implementation (`main.js`)**:
>   - Initialize oscilloscope canvas/context and responsive resizing (`resizeOscilloscopeCanvas`).
>   - Implement waveform circular buffer, downsampling, and BPM-based view window (`calculateViewDuration`, `updateWaveformBufferSize`, `updateWaveform`).
>   - Render scrolling waveform with gradient fill/line and zero-crossing baseline (`drawOscilloscope`).
>   - Integrate updates into existing loop (`update`, `draw`, `animate`) and add change handler for `#view-length`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 626bc95f83452a4acd56b4dfc9560d835b634ece. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->