### PR TITLE
5 need to reassess the thresholds for the energy bands

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,25 @@
     </div>
 
     <script type="module" src="./main.js"></script>
+    
+    <!-- Band Tooltip - Fixed position for guaranteed visibility -->
+    <div
+        id="bandTooltip"
+        style="
+            position: fixed;
+            pointer-events: none;
+            padding: 4px 8px;
+            border-radius: 4px;
+            background: rgba(15, 23, 42, 0.95);
+            color: #fefce8;
+            font-size: 11px;
+            line-height: 1.3;
+            display: none;
+            z-index: 9999;
+            border: 1px solid #facc15;
+            white-space: nowrap;
+        "
+    ></div>
 </body>
 </html>
 


### PR DESCRIPTION
# Refactor energy density bands for dynamic visualization and add bin-based energy computation

Major improvements:
- Separate instant bars from peak hold: instantValue drives main bars, peakValue only for peak cap indicator
- Faster peak decay: peakHoldDecayRate 0.9 (was 0.95), updated decay multipliers (Sub-bass: 0.8, Mids: 1.2, Highs: 1.6)
- Reduce mid-band saturation: category gain (Mids: -2dB, Highs: +3dB), updated thresholds (Sub-bass: -80, Mids: -75, Highs: -78), wider dynamic range (40dB), added normalization curve
- Clean min-visible logic: reduced to 0.02, only applied to drawing

Technical improvements:
- Add bin index computation: compute startBin/endBin for each band using freqPerBin, ensure every band has at least one bin
- Update energy computation: use bin indices directly instead of frequency comparisons for better accuracy
- Request 48kHz AudioContext: match source audio file sample rate
- Fix tooltip implementation: use fixed positioning, correct property names (min/max), display all debug info

Visual changes:
- Main bars now update instantly with music (no peak hold on bars)
- Peak caps show brief visual reference for recent peaks (white indicator)
- More balanced visualization across frequency ranges"